### PR TITLE
Streamline build/update/change process so that RHEL and CentOS have a better shared code path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@
 FROM rhel7
 
 ENV HOME=/opt/app-root/src \
-  PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
-  RUBY_VERSION=2.0 \
+  PATH=/opt/rh/rh-ruby22/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin${PATH:+:${PATH}} \
+  LD_LIBRARY_PATH=/opt/rh/rh-ruby22/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+  MANPATH=/opt/rh/rh-ruby22/root/usr/share/man:$MANPATH \
+  PKG_CONFIG_PATH=/opt/rh/rh-ruby22/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+  XDG_DATA_DIRS=/opt/rh/rh-ruby22/root/usr/share${XDG_DATA_DIRS:+:${XDG_DATA_DIRS}} \
+  RUBY_VERSION=2.2 \
   FLUENTD_VERSION=0.12.32 \
   GEM_HOME=/opt/app-root/src \
   DATA_VERSION=1.6.0 \
@@ -25,50 +29,17 @@ LABEL io.k8s.description="Fluentd container for collecting logs from other fluen
   name="fluentd-forwarder" \
   architecture=x86_64
 
-# build tools for building gems
-# iproute needed for ip command to get ip addresses
-# nss_wrapper used to support username identity
-# bc for calculations in run.conf
-RUN yum install -y --disablerepo=\* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-server-rhscl-7-rpms --enablerepo=rhel-7-server-optional-rpms --setopt=tsflags=nodocs \
-      gcc-c++ \
-      ruby \
-      ruby-devel \
-      libcurl-devel \
-      make \
-      bc \
-      gettext \
-      nss_wrapper \
-      hostname \
-      iproute && \
-    yum clean all
-
-# activesupport version 5.x requires ruby 2.2
-RUN mkdir -p ${HOME} && \
-    gem install -N --conservative --minimal-deps --no-document \
-      fluentd:${FLUENTD_VERSION} \
-      'activesupport:<5' \
-      fluent-plugin-kubernetes_metadata_filter \
-      fluent-plugin-rewrite-tag-filter \
-      fluent-plugin-secure-forward \
-      fluent-plugin-remote_syslog \
-      fluent-plugin-splunk-ex
-
-RUN mkdir -p /etc/fluent && \
-    chgrp -R 0 /etc/fluent && \
-    chmod -R g+rwX /etc/fluent && \
-    chgrp -R 0 ${HOME} && \
-    chmod -R g+rwX ${HOME} && \
-    chgrp -R 0 /etc/pki && \
-    chmod -R g+rwX /etc/pki && \
-    mkdir /secrets && \
-    chgrp -R 0 /secrets && \
-    chmod -R g+rwX /secrets  && \
-    chgrp -R 0 /var/log && \
-    chmod -R g+rwX /var/log     
-
-# copy configuration files
+# add files
 ADD run.sh fluentd.conf.template passwd.template fluentd-check.sh ${HOME}/
-RUN chmod g+rx ${HOME}/fluentd-check.sh
+ADD common-*.sh /tmp/
+
+# set permissions on files
+RUN chmod g+rx ${HOME}/fluentd-check.sh && \
+    chmod +x /tmp/common-*.sh
+
+# execute files and remove when done
+RUN /tmp/common-install.sh && \
+    rm -f /tmp/common-*.sh
 
 # set working dir
 WORKDIR ${HOME}

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -2,8 +2,12 @@
 FROM centos:7
 
 ENV HOME=/opt/app-root/src \
-  PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
-  RUBY_VERSION=2.0 \
+  PATH=/opt/rh/rh-ruby22/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin${PATH:+:${PATH}} \
+  LD_LIBRARY_PATH=/opt/rh/rh-ruby22/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+  MANPATH=/opt/rh/rh-ruby22/root/usr/share/man:$MANPATH \
+  PKG_CONFIG_PATH=/opt/rh/rh-ruby22/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+  XDG_DATA_DIRS=/opt/rh/rh-ruby22/root/usr/share${XDG_DATA_DIRS:+:${XDG_DATA_DIRS}} \
+  RUBY_VERSION=2.2 \
   FLUENTD_VERSION=0.12.32 \
   GEM_HOME=/opt/app-root/src \
   DATA_VERSION=1.6.0 \
@@ -25,52 +29,17 @@ LABEL io.k8s.description="Fluentd container for collecting logs from other fluen
   name="fluentd-forwarder" \
   architecture=x86_64
 
-# build tools for building gems
-# iproute needed for ip command to get ip addresses
-# nss_wrapper used to support username identity
-# bc for calculations in run.conf
-RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    yum install -y epel-release && \
-    yum install -y --setopt=tsflags=nodocs \
-      gcc-c++ \
-      ruby \
-      ruby-devel \
-      libcurl-devel \
-      make \
-      bc \
-      gettext \
-      nss_wrapper \
-      hostname \
-      iproute && \
-    yum clean all
-
-# activesupport version 5.x requires ruby 2.2
-RUN mkdir -p ${HOME} && \
-    gem install -N --conservative --minimal-deps --no-document \
-      fluentd:${FLUENTD_VERSION} \
-      'activesupport:<5' \
-      fluent-plugin-kubernetes_metadata_filter \
-      fluent-plugin-rewrite-tag-filter \
-      fluent-plugin-secure-forward \
-      fluent-plugin-remote_syslog \
-      fluent-plugin-splunk-ex
-
-RUN mkdir -p /etc/fluent && \
-    chgrp -R 0 /etc/fluent && \
-    chmod -R g+rwX /etc/fluent && \
-    chgrp -R 0 ${HOME} && \
-    chmod -R g+rwX ${HOME} && \
-    chgrp -R 0 /etc/pki && \
-    chmod -R g+rwX /etc/pki && \
-    mkdir /secrets && \
-    chgrp -R 0 /secrets && \
-    chmod -R g+rwX /secrets  && \
-    chgrp -R 0 /var/log && \
-    chmod -R g+rwX /var/log   
-
-# copy configuration files
+# add files
 ADD run.sh fluentd.conf.template passwd.template fluentd-check.sh ${HOME}/
-RUN chmod g+rx ${HOME}/fluentd-check.sh
+ADD common-*.sh /tmp/
+
+# set permissions on files
+RUN chmod g+rx ${HOME}/fluentd-check.sh && \
+    chmod +x /tmp/common-*.sh
+
+# execute files and remove when done
+RUN /tmp/common-install.sh && \
+    rm -f /tmp/common-*.sh
 
 # set working dir
 WORKDIR ${HOME}

--- a/common-install.sh
+++ b/common-install.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# get release version
+RELEASE=$(cat /etc/redhat-release)
+YUM_ARGS="--setopt=tsflags=nodocs"
+
+# ensure latest versions
+yum update $YUM_ARGS -y
+
+# shared packages
+PACKAGES="gcc-c++ libcurl-devel make bc gettext nss_wrapper hostname iproute"
+
+# ruby packages
+PACKAGES="${PACKAGES} rh-ruby22 rh-ruby22-rubygems rh-ruby22-ruby-devel"
+
+# if the release is a red hat version then we need to set additional arguments for yum repositories
+RED_HAT_MATCH='^Red Hat.*$'
+if [[ $RELEASE =~ $RED_HAT_MATCH ]]; then
+  YUM_ARGS="${YUM_ARGS} --disablerepo=\* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-server-rhscl-7-rpms --enablerepo=rhel-7-server-optional-rpms"
+fi
+
+# enable epel when on CentOS
+CENTOS_MATCH='^CentOS.*'
+if [[ $RELEASE =~ $CENTOS_MATCH ]]; then
+  rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+  yum install -y epel-release centos-release-scl-rh
+fi
+
+# install all required packages
+yum install -y $YUM_ARGS $PACKAGES
+
+# clean up yum to make sure image isn't larger because of installations/updates
+yum clean all
+rm -rf /var/cache/yum/*
+rm -rf /var/lib/yum/*
+
+# set home directory
+mkdir -p ${HOME} && \
+
+# install gems for target version of fluentd, eventually
+# update to fluentd version that matches version deployed
+# into openshift
+gem install -N --conservative --minimal-deps --no-document \
+  fluentd:${FLUENTD_VERSION} \
+  'activesupport:<5' \
+  'public_suffix:<3.0.0' \
+  'fluent-plugin-record-modifier:<1.0.0' \
+  'fluent-plugin-rewrite-tag-filter:<2.0.0' \
+  fluent-plugin-kubernetes_metadata_filter \
+  fluent-plugin-rewrite-tag-filter \
+  fluent-plugin-secure-forward \
+  'fluent-plugin-remote_syslog:<1.0.0' \
+  fluent-plugin-splunk-ex
+
+# set up directores
+mkdir -p /etc/fluent
+chgrp -R 0 /etc/fluent
+chmod -R g+rwX /etc/fluent
+chgrp -R 0 ${HOME}
+chmod -R g+rwX ${HOME}
+chgrp -R 0 /etc/pki
+chmod -R g+rwX /etc/pki
+mkdir /secrets
+chgrp -R 0 /secrets
+chmod -R g+rwX /secrets
+chgrp -R 0 /var/log
+chmod -R g+rwX /var/log

--- a/common-install.sh
+++ b/common-install.sh
@@ -8,6 +8,10 @@ YUM_ARGS="--setopt=tsflags=nodocs"
 yum update $YUM_ARGS -y
 
 # shared packages
+# - build tools for building gems	+# add files
+# - iproute needed for ip command to get ip addresses	+ADD run.sh fluentd.conf.template passwd.template fluentd-check.sh ${HOME}/
+# - nss_wrapper used to support username identity	+ADD common-*.sh /tmp/
+# - bc for calculations in run.conf
 PACKAGES="gcc-c++ libcurl-devel make bc gettext nss_wrapper hostname iproute"
 
 # ruby packages
@@ -52,7 +56,9 @@ gem install -N --conservative --minimal-deps --no-document \
   'fluent-plugin-remote_syslog:<1.0.0' \
   fluent-plugin-splunk-ex
 
-# set up directores
+# set up directores so that group 0 can have access like specified in
+# https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html
+# https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html#openshift-specific-guidelines
 mkdir -p /etc/fluent
 chgrp -R 0 /etc/fluent
 chmod -R g+rwX /etc/fluent

--- a/fluentd.conf.template
+++ b/fluentd.conf.template
@@ -25,7 +25,7 @@
 </filter>
 
 <match **>
-  type ${TARGET_TYPE}
+  @type ${TARGET_TYPE}
   host ${TARGET_HOST}
   port ${TARGET_PORT}
   ${ADDITIONAL_OPTS}


### PR DESCRIPTION
- implemented shared script that handles the (minimal) differences between RHEL and CentOS and allows the two pipelines be edited without worrying about copy/paste errors.
- implemented same suggestions from PR#17 and PR#18
- fixed issue with newest release of the remote syslog plugin requiring a newer version of fluentd
- updated template syntax to support '@type'