### PR TITLE
adding switch to not touch repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ oc project logging
 oc process fluentd-forwarder-centos | oc apply -f -
 ```
 
+By default the build will disable all repositories in the base image, enabling only the ones required for installing the required packages. If you want to use the build process to use the existing repository config as is (e.g. if you're using a custom base image) then set the `USE_SYSTEM_REPOS` environment variable to any value in the BuildConfig object.
+```
+oc project logging
+oc set env bc/fluentd-forwarder USE_SYSTEM_REPOS=1
+```
+
+On CentOS:
+```
+oc project logging
+oc set env bc/fluentd-forwarder-centos USE_SYSTEM_REPOS=1
+```
+
 Build the fluentd-forwarder
 ```bash
 oc project logging

--- a/common-install.sh
+++ b/common-install.sh
@@ -19,13 +19,13 @@ PACKAGES="${PACKAGES} rh-ruby22 rh-ruby22-rubygems rh-ruby22-ruby-devel"
 
 # if the release is a red hat version then we need to set additional arguments for yum repositories
 RED_HAT_MATCH='^Red Hat.*$'
-if [[ $RELEASE =~ $RED_HAT_MATCH && -z "$DONT_TOUCH_REPOS" ]]; then
+if [[ $RELEASE =~ $RED_HAT_MATCH && -z "$USE_SYSTEM_REPOS" ]]; then
   YUM_ARGS="${YUM_ARGS} --disablerepo=\* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-server-rhscl-7-rpms --enablerepo=rhel-7-server-optional-rpms"
 fi
 
 # enable epel when on CentOS
 CENTOS_MATCH='^CentOS.*'
-if [[ $RELEASE =~ $CENTOS_MATCH && -z "$DONT_TOUCH_REPOS" ]]; then
+if [[ $RELEASE =~ $CENTOS_MATCH && -z "$USE_SYSTEM_REPOS" ]]; then
   rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
   yum install -y epel-release centos-release-scl-rh
 fi

--- a/common-install.sh
+++ b/common-install.sh
@@ -19,13 +19,13 @@ PACKAGES="${PACKAGES} rh-ruby22 rh-ruby22-rubygems rh-ruby22-ruby-devel"
 
 # if the release is a red hat version then we need to set additional arguments for yum repositories
 RED_HAT_MATCH='^Red Hat.*$'
-if [[ $RELEASE =~ $RED_HAT_MATCH ]]; then
+if [[ $RELEASE =~ $RED_HAT_MATCH && -z "$DONT_TOUCH_REPOS" ]]; then
   YUM_ARGS="${YUM_ARGS} --disablerepo=\* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-server-rhscl-7-rpms --enablerepo=rhel-7-server-optional-rpms"
 fi
 
 # enable epel when on CentOS
 CENTOS_MATCH='^CentOS.*'
-if [[ $RELEASE =~ $CENTOS_MATCH ]]; then
+if [[ $RELEASE =~ $CENTOS_MATCH && -z "$DONT_TOUCH_REPOS" ]]; then
   rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
   yum install -y epel-release centos-release-scl-rh
 fi


### PR DESCRIPTION
This commit adds a switch for the installer script to not touch the yum repo config at all. This is necessary in restricted environments where the default repos might be unavailable but internal ones had been configured in a custom base image. It does not change the current behaviour of the installer script. When provided with a non-empty `DONT_TOUCH_REPOS` environment variable at build time the installer will take the repo config as is and not change it at all.