### PR TITLE
Add Splunk HTTP support, updated README, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@
     * [Environment Setup](#environment-setup)
     * [Create Build Configuration](#create-build-configuration)
     * [Create Fluentd Forwarder](#create-fluentd-forwarder)
+      * [RHEL](#rhel)
+        * [RHEL Rsyslog](#rhel-rsyslog)
+        * [RHEL splunkex](#rhel-splunkex)
+        * [RHEL splunkhec](#rhel-splunkhec)
+      * [CentOS](#centos)
+        * [CentOS Rsyslog](#centos-rsyslog)
+        * [CentOS splunkex](#centos-splunkex)
+        * [CentOS splunkhec](#centos-splunkhec)
     * [Configure Fluentd Loggers](#configure-fluentd-loggers)
     * [Additional Configuration](#additional-configuration)
       * [Filtering](#filtering)
@@ -141,7 +149,11 @@ oc project logging
 oc apply -f fluentd-forwarder-template.yaml
 ```
 
-Create the new logging forwarder application deployment:
+#### RHEL
+
+##### RHEL Rsyslog
+
+Create the new rsyslog logging forwarder application deployment:
 ```bash
 oc project logging
 oc new-app fluentd-forwarder \
@@ -151,16 +163,75 @@ oc new-app fluentd-forwarder \
    -p "P_SHARED_KEY=changeme"
 ```
 
+##### RHEL splunkex
+
+To create the new splunk-ex logging forwarder application deployment:
+```bash
+oc project logging && \
+oc process -f fluentd-forwarder-template.yaml \
+   -p "P_TARGET_TYPE=splunk_ex" \
+   -p "P_TARGET_HOST=10.10.10.10" \
+   -p "P_TARGET_PORT=9997" \
+   -p "P_SHARED_KEY=changeme" \
+   -p "P_ADDITIONAL_OPTS=output_format json"
+```
+
+##### RHEL splunkhec
+
+To create the new splunkhec logging forwarder application deployment:
+```bash
+oc project logging
+oc new-app fluentd-forwarder \
+   -p P_TARGET_TYPE="splunkhec" \
+   -p P_TARGET_HOST="examplehec.example.com" \
+   -p P_TARGET_PORT="8088" \
+   -p P_SHARED_KEY="changeme" \
+   -p P_ADDITIONAL_OPTS="token <token_value>"
+```
+
+#### CentOS
+
+##### CentOS Rsyslog
+
 To do the same for CentOS you need to reference the ImageStream created by that build.
 ```bash
 oc project logging
 oc new-app fluentd-forwarder \
-   -p "P_IMAGE_NAME=fluentd-forwarder-centos"
+   -p "P_IMAGE_NAME=fluentd-forwarder-centos" \
    -p "P_TARGET_TYPE=remote_syslog" \
    -p "P_TARGET_HOST=rsyslog.internal.company.com" \
    -p "P_TARGET_PORT=514" \
    -p "P_SHARED_KEY=changeme"
 ```
+
+##### CentOS splunkex
+
+To create the new splunk-ex logging forwarder application deployment:
+```bash
+oc project logging && \
+oc process -f fluentd-forwarder-template.yaml \
+   -p "P_IMAGE_NAME=fluentd-forwarder-centos" \
+   -p "P_TARGET_TYPE=splunk_ex" \
+   -p "P_TARGET_HOST=10.10.10.10" \
+   -p "P_TARGET_PORT=9997" \
+   -p "P_SHARED_KEY=changeme" \
+   -p "P_ADDITIONAL_OPTS=output_format json"
+```
+
+##### CentOS splunkhec
+
+To create the new splunkhec logging forwarder application deployment:
+```bash
+oc project logging
+oc new-app fluentd-forwarder \
+   -p "P_IMAGE_NAME=fluentd-forwarder-centos" \
+   -p P_TARGET_TYPE="splunkhec" \
+   -p P_TARGET_HOST="examplehec.example.com" \
+   -p P_TARGET_PORT="8088" \
+   -p P_SHARED_KEY="changeme" \
+   -p P_ADDITIONAL_OPTS="token <token_value>"
+```
+
 
 A full list of parameters can be found in the [template](./fluentd-forwarder-template.yaml). Additional non-parameterized parameters and environment variables can be found in the [Dockerfile](./Dockerfile).
 

--- a/common-install.sh
+++ b/common-install.sh
@@ -54,7 +54,8 @@ gem install -N --conservative --minimal-deps --no-document \
   fluent-plugin-rewrite-tag-filter \
   fluent-plugin-secure-forward \
   'fluent-plugin-remote_syslog:<1.0.0' \
-  fluent-plugin-splunk-ex
+  fluent-plugin-splunk-ex \
+  fluent-plugin-splunkhec
 
 # set up directores so that group 0 can have access like specified in
 # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html

--- a/common-install.sh
+++ b/common-install.sh
@@ -4,8 +4,6 @@
 RELEASE=$(cat /etc/redhat-release)
 YUM_ARGS="--setopt=tsflags=nodocs"
 
-# ensure latest versions
-yum update $YUM_ARGS -y
 
 # shared packages
 # - build tools for building gems	+# add files
@@ -20,7 +18,11 @@ PACKAGES="${PACKAGES} rh-ruby22 rh-ruby22-rubygems rh-ruby22-ruby-devel"
 # if the release is a red hat version then we need to set additional arguments for yum repositories
 RED_HAT_MATCH='^Red Hat.*$'
 if [[ $RELEASE =~ $RED_HAT_MATCH && -z "$USE_SYSTEM_REPOS" ]]; then
-  YUM_ARGS="${YUM_ARGS} --disablerepo=\* --enablerepo=rhel-7-server-rpms --enablerepo=rhel-server-rhscl-7-rpms --enablerepo=rhel-7-server-optional-rpms"
+  #NOTE: Until the first yum command is run, /etc/yum.repos.d/redhat.repo contains no repositories, so yum-config-manager will not enable/disable anything.
+  #This command will force the population of said file, see #https://access.redhat.com/solutions/1443553
+  yum repolist --disablerepo=* && yum-config-manager --disable \* > /dev/null
+  #Set YUM_ARGS
+  YUM_ARGS="${YUM_ARGS} --enablerepo=rhel-7-server-rpms --enablerepo=rhel-server-rhscl-7-rpms --enablerepo=rhel-7-server-optional-rpms"
 fi
 
 # enable epel when on CentOS
@@ -29,6 +31,9 @@ if [[ $RELEASE =~ $CENTOS_MATCH && -z "$USE_SYSTEM_REPOS" ]]; then
   rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
   yum install -y epel-release centos-release-scl-rh
 fi
+
+# ensure latest versions
+yum update $YUM_ARGS -y
 
 # install all required packages
 yum install -y $YUM_ARGS $PACKAGES

--- a/common-install.sh
+++ b/common-install.sh
@@ -12,7 +12,7 @@ yum update $YUM_ARGS -y
 # - iproute needed for ip command to get ip addresses	+ADD run.sh fluentd.conf.template passwd.template fluentd-check.sh ${HOME}/
 # - nss_wrapper used to support username identity	+ADD common-*.sh /tmp/
 # - bc for calculations in run.conf
-PACKAGES="gcc-c++ libcurl-devel make bc gettext nss_wrapper hostname iproute"
+PACKAGES="gem gcc-c++ libcurl-devel make bc gettext nss_wrapper hostname iproute"
 
 # ruby packages
 PACKAGES="${PACKAGES} rh-ruby22 rh-ruby22-rubygems rh-ruby22-ruby-devel"

--- a/fluentd-forwarder-template.yaml
+++ b/fluentd-forwarder-template.yaml
@@ -142,7 +142,7 @@ objects:
       </filter>
 
       <match **>
-        type ${TARGET_TYPE}
+        @type ${TARGET_TYPE}
         host ${TARGET_HOST}
         port ${TARGET_PORT}
         ${ADDITIONAL_OPTS}


### PR DESCRIPTION
-Add support for Splunk HTTP endpoints
-Update README with samples for Splunk TCP and HTTP
-Update Type tag to fix deprecation warning
-Update common script to perform yum actions as prescribed by Red Hat
-Confirmed working on OCP 3.7.46 & 3.9.27